### PR TITLE
with delayed queue to manage orders which didn‘t pay in the normalOrderOvertime of order setting

### DIFF
--- a/mall-portal/src/main/java/com/macro/mall/portal/component/OrderDelayedTask.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/OrderDelayedTask.java
@@ -12,9 +12,12 @@ public class OrderDelayedTask implements Delayed {
     /**延时时间 单位 timeunit.milliseconds**/
     private long timeout;
 
+    private long expire;
+
     public OrderDelayedTask(OmsOrder order, long timeout){
         this.omsOrder = order;
         this.timeout = timeout;
+        this.expire = System.currentTimeMillis() + timeout;
     }
 
     public OmsOrder getOmsOrder() {
@@ -23,7 +26,7 @@ public class OrderDelayedTask implements Delayed {
 
     @Override
     public long getDelay(TimeUnit unit) {
-        return unit.convert(omsOrder.getCreateTime().getTime() - timeout,TimeUnit.MILLISECONDS);
+        return unit.convert(expire - System.currentTimeMillis(),TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/mall-portal/src/main/java/com/macro/mall/portal/component/OrderDelayedTask.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/OrderDelayedTask.java
@@ -1,0 +1,41 @@
+package com.macro.mall.portal.component;
+
+import com.macro.mall.model.OmsOrder;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+public class OrderDelayedTask implements Delayed {
+
+
+    private OmsOrder omsOrder;
+    /**延时时间 单位 timeunit.milliseconds**/
+    private long timeout;
+
+    public OrderDelayedTask(OmsOrder order, long timeout){
+        this.omsOrder = order;
+        this.timeout = timeout;
+    }
+
+    public OmsOrder getOmsOrder() {
+        return omsOrder;
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return unit.convert(omsOrder.getCreateTime().getTime() - timeout,TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return (int) (this.getDelay(TimeUnit.MILLISECONDS) -o.getDelay(TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public String toString() {
+        return "OrderDelayedTask{" +
+                "omsOrder=" + omsOrder +
+                ", timeout=" + timeout +
+                '}';
+    }
+}

--- a/mall-portal/src/main/java/com/macro/mall/portal/component/OrderQueueManager.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/OrderQueueManager.java
@@ -1,0 +1,90 @@
+package com.macro.mall.portal.component;
+
+import com.google.common.collect.Lists;
+import com.macro.mall.model.OmsOrder;
+import com.macro.mall.model.UmsMember;
+import com.macro.mall.portal.dao.PortalOrderDao;
+import com.macro.mall.portal.domain.OmsOrderDetail;
+import com.macro.mall.portal.service.OmsPortalOrderService;
+import com.macro.mall.portal.service.UmsMemberService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.DelayQueue;
+
+@Slf4j
+@Component
+public class OrderQueueManager {
+
+
+    private DelayQueue<OrderDelayedTask> queue;
+
+    // 守护线程
+    private Thread daemonThread;
+
+    @Autowired
+    private PortalOrderDao portalOrderDao;
+
+    @Autowired
+    private UmsMemberService memberService;
+
+    @Autowired
+    private OmsPortalOrderService orderService;
+
+
+    private static OrderQueueManager instance = new OrderQueueManager();
+
+    private OrderQueueManager() {
+        queue = new DelayQueue<>();
+        init();
+    }
+
+    public static OrderQueueManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * 初始化
+     */
+    public void init() {
+        daemonThread = new Thread(() -> execute());
+        daemonThread.setName("DelayQueueMonitor");
+        daemonThread.start();
+    }
+
+
+    public void execute() {
+        while (true) {
+            log.info("当前延时队列的任务数量:{}", queue.size());
+            try {
+                OrderDelayedTask task = queue.take();
+                if (null == task) {
+                    continue;
+                }
+                OmsOrder omsOrder = task.getOmsOrder();
+                portalOrderDao.updateOrderStatus(Lists.newArrayList(omsOrder.getId()), 4);
+                OmsOrderDetail timeOutOrder = portalOrderDao.getDetail(omsOrder.getId());
+                //解除订单商品库存锁定
+                portalOrderDao.releaseSkuStockLock(timeOutOrder.getOrderItemList());
+                //修改优惠券使用状态
+                orderService.updateCouponStatus(timeOutOrder.getCouponId(), timeOutOrder.getMemberId(), 0);
+                //返还使用积分
+                if (timeOutOrder.getUseIntegration() != null) {
+                    UmsMember member = memberService.getById(timeOutOrder.getMemberId());
+                    memberService.updateIntegration(timeOutOrder.getMemberId(), member.getIntegration() + timeOutOrder.getUseIntegration());
+                }
+            } catch (InterruptedException e) {
+                log.error("获取延时任务失败！", e.getMessage());
+            }
+        }
+    }
+
+    public void setQueue(OrderDelayedTask task) {
+        queue.put(task);
+    }
+
+    public void removeQueue(OrderDelayedTask task) {
+        queue.remove(task);
+    }
+}

--- a/mall-portal/src/main/java/com/macro/mall/portal/component/OrderTimeOutCancelTask.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/OrderTimeOutCancelTask.java
@@ -22,9 +22,9 @@ public class OrderTimeOutCancelTask {
      * cron表达式：Seconds Minutes Hours DayofMonth Month DayofWeek [Year]
      * 每10分钟扫描一次，扫描设定超时时间之前下的订单，如果没支付则取消该订单
      */
-    @Scheduled(cron = "0 0/10 * ? * ?")
-    private void cancelTimeOutOrder(){
-        CommonResult result = portalOrderService.cancelTimeOutOrder();
-        LOGGER.info("取消订单，并根据sku编号释放锁定库存:{}",result);
-    }
+//    @Scheduled(cron = "0 0/10 * ? * ?")
+//    private void cancelTimeOutOrder(){
+//        CommonResult result = portalOrderService.cancelTimeOutOrder();
+//        LOGGER.info("取消订单，并根据sku编号释放锁定库存:{}",result);
+//    }
 }

--- a/mall-portal/src/main/java/com/macro/mall/portal/service/OmsPortalOrderService.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/OmsPortalOrderService.java
@@ -43,4 +43,9 @@ public interface OmsPortalOrderService {
      * 发送延迟消息取消订单
      */
     void sendDelayMessageCancelOrder(Long orderId);
+
+    /**
+     * 优惠券信息更改为指定状态
+     */
+    void updateCouponStatus(Long couponId, Long memberId, Integer useStatus);
 }


### PR DESCRIPTION
**问题**
之前通过定时器去定时检查超时时间之前下的订单，如果没支付则取消该订单，不能保证未支付订单在相同的时间内被取消订单，例如有的是15分钟未支付就被取消订单，有的是20分钟，因离定时器的时间而不同；
**解决办法**
将订单放入到延时队列，在orderSetting设定的一般订单的实效时间，对未支付的订单进行取消，可以实现未支付的订单在相同的时间内会被取消。