### PR TITLE
对IgnoreUrlsConfig文件添加Getter和Setter访问属性

### DIFF
--- a/mall-security/src/main/java/com/macro/mall/security/config/IgnoreUrlsConfig.java
+++ b/mall-security/src/main/java/com/macro/mall/security/config/IgnoreUrlsConfig.java
@@ -18,4 +18,11 @@ public class IgnoreUrlsConfig {
 
     private List<String> urls = new ArrayList<>();
 
+    public List<String> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(List<String> urls) {
+        this.urls = urls;
+    }
 }


### PR DESCRIPTION
修复mall-security包中IgnoreUrlsConfig文件缺少Getter和Setter属性，导致SecurityConfig出现编译异常