### PR TITLE
Fix relatebugs

### DIFF
--- a/document/docker/docker-compose-env.yml
+++ b/document/docker/docker-compose-env.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mysql:
-    image: mysql:8.0.31
+    image: mysql:5.7
     container_name: mysql
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
@@ -10,32 +10,32 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/data/db:/var/lib/mysql #数据文件挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/data/conf:/etc/mysql/conf.d #配置文件挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/log:/var/log/mysql #日志文件挂载
+      - /mydata/mysql/data/db:/var/lib/mysql #数据文件挂载
+      - /mydata/mysql/data/conf:/etc/mysql/conf.d #配置文件挂载
+      - /mydata/mysql/log:/var/log/mysql #日志文件挂载
   redis:
     image: redis:7
     container_name: redis
     command: redis-server --appendonly yes
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/redis/data:/data #数据文件挂载
+      - /mydata/redis/data:/data #数据文件挂载
     ports:
       - 6379:6379
   nginx:
     image: nginx:1.22
     container_name: nginx
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/nginx.conf:/etc/nginx/nginx.conf #配置文件挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/html:/usr/share/nginx/html #静态资源根目录挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/log:/var/log/nginx #日志文件挂载
+      - /mydata/nginx/nginx.conf:/etc/nginx/nginx.conf #配置文件挂载
+      - /mydata/nginx/html:/usr/share/nginx/html #静态资源根目录挂载
+      - /mydata/nginx/log:/var/log/nginx #日志文件挂载
     ports:
       - 80:80
   rabbitmq:
     image: rabbitmq:3.9-management
     container_name: rabbitmq
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/rabbitmq/data:/var/lib/rabbitmq #数据文件挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/rabbitmq/log:/var/log/rabbitmq #日志文件挂载
+      - /mydata/rabbitmq/data:/var/lib/rabbitmq #数据文件挂载
+      - /mydata/rabbitmq/log:/var/log/rabbitmq #日志文件挂载
     ports:
       - 5672:5672
       - 15672:15672
@@ -45,10 +45,10 @@ services:
     environment:
       - "cluster.name=elasticsearch" #设置集群名称为elasticsearch
       - "discovery.type=single-node" #以单一节点模式启动
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" #设置使用jvm内存大小
+      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m" #设置使用jvm内存大小
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/plugins:/usr/share/elasticsearch/plugins #插件文件挂载
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/data:/usr/share/elasticsearch/data #数据文件挂载
+      - /mydata/elasticsearch/plugins:/usr/share/elasticsearch/plugins #插件文件挂载
+      - /mydata/elasticsearch/data:/usr/share/elasticsearch/data #数据文件挂载
     ports:
       - 9200:9200
       - 9300:9300
@@ -58,7 +58,7 @@ services:
     environment:
       - TZ=Asia/Shanghai
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf #挂载logstash的配置文件
+      - /mydata/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf #挂载logstash的配置文件
     depends_on:
       - elasticsearch #kibana在elasticsearch启动之后再启动
     links:
@@ -83,6 +83,6 @@ services:
     image: mongo:4
     container_name: mongo
     volumes:
-      - /Users/zhuqianchao/Documents/dev/docker-mysql/mongo/db:/data/db #数据文件挂载
+      - /mydata/mongo/db:/data/db #数据文件挂载
     ports:
       - 27017:27017

--- a/document/docker/docker-compose-env.yml
+++ b/document/docker/docker-compose-env.yml
@@ -45,7 +45,7 @@ services:
     environment:
       - "cluster.name=elasticsearch" #设置集群名称为elasticsearch
       - "discovery.type=single-node" #以单一节点模式启动
-      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m" #设置使用jvm内存大小
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" #设置使用jvm内存大小
     volumes:
       - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/plugins:/usr/share/elasticsearch/plugins #插件文件挂载
       - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/data:/usr/share/elasticsearch/data #数据文件挂载

--- a/document/docker/docker-compose-env.yml
+++ b/document/docker/docker-compose-env.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0.31
     container_name: mysql
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
@@ -10,32 +10,32 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - /mydata/mysql/data/db:/var/lib/mysql #数据文件挂载
-      - /mydata/mysql/data/conf:/etc/mysql/conf.d #配置文件挂载
-      - /mydata/mysql/log:/var/log/mysql #日志文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/data/db:/var/lib/mysql #数据文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/data/conf:/etc/mysql/conf.d #配置文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/log:/var/log/mysql #日志文件挂载
   redis:
     image: redis:7
     container_name: redis
     command: redis-server --appendonly yes
     volumes:
-      - /mydata/redis/data:/data #数据文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/redis/data:/data #数据文件挂载
     ports:
       - 6379:6379
   nginx:
     image: nginx:1.22
     container_name: nginx
     volumes:
-      - /mydata/nginx/nginx.conf:/etc/nginx/nginx.conf #配置文件挂载
-      - /mydata/nginx/html:/usr/share/nginx/html #静态资源根目录挂载
-      - /mydata/nginx/log:/var/log/nginx #日志文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/nginx.conf:/etc/nginx/nginx.conf #配置文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/html:/usr/share/nginx/html #静态资源根目录挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/nginx/log:/var/log/nginx #日志文件挂载
     ports:
       - 80:80
   rabbitmq:
     image: rabbitmq:3.9-management
     container_name: rabbitmq
     volumes:
-      - /mydata/rabbitmq/data:/var/lib/rabbitmq #数据文件挂载
-      - /mydata/rabbitmq/log:/var/log/rabbitmq #日志文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/rabbitmq/data:/var/lib/rabbitmq #数据文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/rabbitmq/log:/var/log/rabbitmq #日志文件挂载
     ports:
       - 5672:5672
       - 15672:15672
@@ -47,8 +47,8 @@ services:
       - "discovery.type=single-node" #以单一节点模式启动
       - "ES_JAVA_OPTS=-Xms512m -Xmx1024m" #设置使用jvm内存大小
     volumes:
-      - /mydata/elasticsearch/plugins:/usr/share/elasticsearch/plugins #插件文件挂载
-      - /mydata/elasticsearch/data:/usr/share/elasticsearch/data #数据文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/plugins:/usr/share/elasticsearch/plugins #插件文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/elasticsearch/data:/usr/share/elasticsearch/data #数据文件挂载
     ports:
       - 9200:9200
       - 9300:9300
@@ -58,7 +58,7 @@ services:
     environment:
       - TZ=Asia/Shanghai
     volumes:
-      - /mydata/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf #挂载logstash的配置文件
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf #挂载logstash的配置文件
     depends_on:
       - elasticsearch #kibana在elasticsearch启动之后再启动
     links:
@@ -83,6 +83,6 @@ services:
     image: mongo:4
     container_name: mongo
     volumes:
-      - /mydata/mongo/db:/data/db #数据文件挂载
+      - /Users/zhuqianchao/Documents/dev/docker-mysql/mongo/db:/data/db #数据文件挂载
     ports:
       - 27017:27017

--- a/mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java
+++ b/mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.nested.ParsedNested;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;

--- a/mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java
+++ b/mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.nested.ParsedNested;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -265,7 +266,7 @@ public class EsProductServiceImpl implements EsProductService {
         productRelatedInfo.setProductCategoryNames(productCategoryNameList);
         //设置参数
         Aggregation productAttrs = aggregationMap.get("allAttrValues");
-        List<? extends Terms.Bucket> attrIds = ((ParsedLongTerms) ((ParsedFilter) ((ParsedNested) productAttrs).getAggregations().get("productAttrs")).getAggregations().get("attrIds")).getBuckets();
+        List<? extends Terms.Bucket> attrIds = ((ParsedTerms) ((ParsedFilter) ((ParsedNested) productAttrs).getAggregations().get("productAttrs")).getAggregations().get("attrIds")).getBuckets();
         List<EsProductRelatedInfo.ProductAttr> attrList = new ArrayList<>();
         for (Terms.Bucket attrId : attrIds) {
             EsProductRelatedInfo.ProductAttr attr = new EsProductRelatedInfo.ProductAttr();


### PR DESCRIPTION
在mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java中
如果当 /search/relate 请求参数为空的时候， 会直接导致((ParsedTerms) ((ParsedFilter) ((ParsedNested) productAttrs).getAggregations().get("productAttrs")).getAggregations().get("attrIds")).getBuckets()   类型为ParsedStringTerms  而非 ParsedLongTerms ， 进而导致强转失败

现将ParsedLongTerms  使用父类ParsedTerms 强转，就可以避免类型问题了