### PR TITLE
用户添加时(/admin/register)后端没有接收status参数并固定将status设置为1

### DIFF
--- a/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
+++ b/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
@@ -29,6 +29,7 @@ public class UmsAdminParam {
     private String nickName;
     @ApiModelProperty(value = "备注")
     private String note;
+    @NotEmpty
     @ApiModelProperty(value = "用户帐号启用状态：0->禁用；1->启用")
     private Integer status;
 }

--- a/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
+++ b/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
@@ -29,7 +29,6 @@ public class UmsAdminParam {
     private String nickName;
     @ApiModelProperty(value = "备注")
     private String note;
-    @NotEmpty
     @ApiModelProperty(value = "用户帐号启用状态：0->禁用；1->启用")
     private Integer status;
 }

--- a/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
+++ b/mall-admin/src/main/java/com/macro/mall/dto/UmsAdminParam.java
@@ -29,4 +29,6 @@ public class UmsAdminParam {
     private String nickName;
     @ApiModelProperty(value = "备注")
     private String note;
+    @ApiModelProperty(value = "用户帐号启用状态：0->禁用；1->启用")
+    private Integer status;
 }

--- a/mall-admin/src/main/java/com/macro/mall/service/impl/UmsAdminServiceImpl.java
+++ b/mall-admin/src/main/java/com/macro/mall/service/impl/UmsAdminServiceImpl.java
@@ -78,7 +78,6 @@ public class UmsAdminServiceImpl implements UmsAdminService {
         UmsAdmin umsAdmin = new UmsAdmin();
         BeanUtils.copyProperties(umsAdminParam, umsAdmin);
         umsAdmin.setCreateTime(new Date());
-        umsAdmin.setStatus(1);
         //查询是否有相同用户名的用户
         UmsAdminExample example = new UmsAdminExample();
         example.createCriteria().andUsernameEqualTo(umsAdmin.getUsername());


### PR DESCRIPTION
问题: 用户添加时(/admin/register)后端没有接收status参数并固定将status设置为1
解决: 在响应的dto中添加了status字段 , 并将固定设置1的操作删除