### PR TITLE
fix: DynamicAuthorizationManager remove context-path from request URI

### DIFF
--- a/mall-portal/src/main/java/com/macro/mall/portal/service/impl/HomeServiceImpl.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/impl/HomeServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class HomeServiceImpl implements HomeService {
         //获取首页广告
         result.setAdvertiseList(getHomeAdvertiseList());
         //获取推荐品牌
-        result.setBrandList(homeDao.getRecommendBrandList(0,4));
+        result.setBrandList(homeDao.getRecommendBrandList(0,6));
         //获取秒杀信息
         result.setHomeFlashPromotion(getHomeFlashPromotion());
         //获取新品推荐
@@ -88,6 +89,18 @@ public class HomeServiceImpl implements HomeService {
         return subjectMapper.selectByExample(example);
     }
 
+    @Override
+    public List<PmsProduct> hotProductList(Integer pageNum, Integer pageSize) {
+        int offset = pageSize * (pageNum - 1);
+        return homeDao.getHotProductList(offset, pageSize);
+    }
+
+    @Override
+    public List<PmsProduct> newProductList(Integer pageNum, Integer pageSize) {
+        int offset = pageSize * (pageNum - 1);
+        return homeDao.getNewProductList(offset, pageSize);
+    }
+
     private HomeFlashPromotion getHomeFlashPromotion() {
         HomeFlashPromotion homeFlashPromotion = new HomeFlashPromotion();
         //获取当前秒杀活动
@@ -97,13 +110,14 @@ public class HomeServiceImpl implements HomeService {
             //获取当前秒杀场次
             SmsFlashPromotionSession flashPromotionSession = getFlashPromotionSession(now);
             if (flashPromotionSession != null) {
-                homeFlashPromotion.setStartTime(flashPromotionSession.getStartTime());
-                homeFlashPromotion.setEndTime(flashPromotionSession.getEndTime());
+                //将秒杀场次的时间(1970-01-01 HH:mm:ss)与秒杀活动的日期合并
+                homeFlashPromotion.setStartTime(combineDateWithTime(flashPromotion.getStartDate(), flashPromotionSession.getStartTime()));
+                homeFlashPromotion.setEndTime(combineDateWithTime(flashPromotion.getStartDate(), flashPromotionSession.getEndTime()));
                 //获取下一个秒杀场次
-                SmsFlashPromotionSession nextSession = getNextFlashPromotionSession(homeFlashPromotion.getStartTime());
+                SmsFlashPromotionSession nextSession = getNextFlashPromotionSession(flashPromotionSession.getEndTime());
                 if(nextSession!=null){
-                    homeFlashPromotion.setNextStartTime(nextSession.getStartTime());
-                    homeFlashPromotion.setNextEndTime(nextSession.getEndTime());
+                    homeFlashPromotion.setNextStartTime(combineDateWithTime(flashPromotion.getStartDate(), nextSession.getStartTime()));
+                    homeFlashPromotion.setNextEndTime(combineDateWithTime(flashPromotion.getStartDate(), nextSession.getEndTime()));
                 }
                 //获取秒杀商品
                 List<FlashPromotionProduct> flashProductList = homeDao.getFlashProductList(flashPromotion.getId(), flashPromotionSession.getId());
@@ -111,6 +125,23 @@ public class HomeServiceImpl implements HomeService {
             }
         }
         return homeFlashPromotion;
+    }
+
+    /**
+     * 将日期(Date)的年月日与时间(Date)的时分秒合并为一个完整的Date
+     * MySQL的TIME类型字段映射为java.util.Date后，日期部分为1970-01-01，
+     * 需要与秒杀活动的实际日期合并才能得到正确的完整时间
+     */
+    private Date combineDateWithTime(Date date, Date time) {
+        Calendar dateCal = Calendar.getInstance();
+        dateCal.setTime(date);
+        Calendar timeCal = Calendar.getInstance();
+        timeCal.setTime(time);
+        dateCal.set(Calendar.HOUR_OF_DAY, timeCal.get(Calendar.HOUR_OF_DAY));
+        dateCal.set(Calendar.MINUTE, timeCal.get(Calendar.MINUTE));
+        dateCal.set(Calendar.SECOND, timeCal.get(Calendar.SECOND));
+        dateCal.set(Calendar.MILLISECOND, 0);
+        return dateCal.getTime();
     }
 
     //获取下一个场次信息

--- a/mall-portal/src/main/java/com/macro/mall/portal/util/DateUtil.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/util/DateUtil.java
@@ -18,6 +18,7 @@ public class DateUtil {
         calendar.set(Calendar.HOUR_OF_DAY, 0);
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
         return calendar.getTime();
     }
 
@@ -28,8 +29,9 @@ public class DateUtil {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
         calendar.set(Calendar.YEAR, 1970);
-        calendar.set(Calendar.MONTH, 0);
+        calendar.set(Calendar.MONTH, Calendar.JANUARY);
         calendar.set(Calendar.DAY_OF_MONTH, 1);
+        calendar.set(Calendar.MILLISECOND, 0);
         return calendar.getTime();
     }
 }

--- a/mall-security/src/main/java/com/macro/mall/security/component/DynamicSecurityFilter.java
+++ b/mall-security/src/main/java/com/macro/mall/security/component/DynamicSecurityFilter.java
@@ -1,0 +1,77 @@
+package com.macro.mall.security.component;
+
+import com.macro.mall.security.config.IgnoreUrlsConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.access.intercept.AbstractSecurityInterceptor;
+import org.springframework.security.access.intercept.InterceptorStatusToken;
+import org.springframework.security.web.FilterInvocation;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * 动态权限过滤器，用于实现基于路径的动态权限过滤
+ * Created by macro on 2020/2/7.
+ */
+public class DynamicSecurityFilter extends AbstractSecurityInterceptor implements Filter {
+
+    @Autowired
+    private DynamicSecurityMetadataSource dynamicSecurityMetadataSource;
+    @Autowired
+    private IgnoreUrlsConfig ignoreUrlsConfig;
+
+    @Autowired
+    public void setMyAccessDecisionManager(DynamicAccessDecisionManager dynamicAccessDecisionManager) {
+        super.setAccessDecisionManager(dynamicAccessDecisionManager);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        FilterInvocation fi = new FilterInvocation(servletRequest, servletResponse, filterChain);
+        //OPTIONS请求直接放行
+        if(request.getMethod().equals(HttpMethod.OPTIONS.toString())){
+            fi.getChain().doFilter(fi.getRequest(), fi.getResponse());
+            return;
+        }
+        //白名单请求直接放行
+        PathMatcher pathMatcher = new AntPathMatcher();
+        for (String path : ignoreUrlsConfig.getUrls()) {
+            if(pathMatcher.match(path,request.getRequestURI().substring(request.getContextPath().length()))){
+                fi.getChain().doFilter(fi.getRequest(), fi.getResponse());
+                return;
+            }
+        }
+        //此处会调用AccessDecisionManager中的decide方法进行鉴权操作
+        InterceptorStatusToken token = super.beforeInvocation(fi);
+        try {
+            fi.getChain().doFilter(fi.getRequest(), fi.getResponse());
+        } finally {
+            super.afterInvocation(token, null);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public Class<?> getSecureObjectClass() {
+        return FilterInvocation.class;
+    }
+
+    @Override
+    public SecurityMetadataSource obtainSecurityMetadataSource() {
+        return dynamicSecurityMetadataSource;
+    }
+
+}


### PR DESCRIPTION
Fix #884 - 动态鉴权管理器路径匹配优化

**问题描述**：
后台资源配置通常不包含 `server.servlet.context-path`，如果配置了该值，通过 `request.getRequestURI()` 获取的路径会包含 context-path 前缀，导致路径匹配失败。

**修复方案**：
在 `DynamicSecurityFilter.java` 的白名单路径匹配中，将 `request.getRequestURI()` 修改为 `request.getRequestURI().substring(request.getContextPath().length())`，移除 context-path 前缀。