### PR TITLE
fix: remove context-path from request URI in DynamicSecurityFilter

### DIFF
--- a/mall-security/src/main/java/com/macro/mall/security/component/DynamicSecurityFilter.java
+++ b/mall-security/src/main/java/com/macro/mall/security/component/DynamicSecurityFilter.java
@@ -46,7 +46,7 @@ public class DynamicSecurityFilter extends AbstractSecurityInterceptor implement
         //白名单请求直接放行
         PathMatcher pathMatcher = new AntPathMatcher();
         for (String path : ignoreUrlsConfig.getUrls()) {
-            if(pathMatcher.match(path,request.getRequestURI())){
+            if(pathMatcher.match(path,request.getRequestURI().substring(request.getContextPath().length()))){
                 fi.getChain().doFilter(fi.getRequest(), fi.getResponse());
                 return;
             }


### PR DESCRIPTION
## Fix #884 - 动态鉴权管理器路径匹配优化

### 问题
后台资源配置通常不包含 `server.servlet.context-path`，如果配置了该值，通过 `request.getRequestURI()` 获取的路径会包含 context-path 前缀，导致路径匹配失败。

### 修复
将 `request.getRequestURI()` 改为 `request.getRequestURI().substring(request.getContextPath().length())`

### 修改文件
`mall-security/src/main/java/com/macro/mall/security/component/DynamicSecurityFilter.java`

Fixes #884