### PR TITLE
fix: 修复优惠券金额分摊计算精度问题 (Issue #356)

### DIFF
--- a/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java
@@ -673,9 +673,21 @@ public class OmsPortalOrderServiceImpl implements OmsPortalOrderService {
      */
     private void calcPerCouponAmount(List<OmsOrderItem> orderItemList, SmsCoupon coupon) {
         BigDecimal totalAmount = calcTotalAmount(orderItemList);
-        for (OmsOrderItem orderItem : orderItemList) {
-            //(商品价格/可用商品总价)*优惠券面额
-            BigDecimal couponAmount = orderItem.getProductPrice().divide(totalAmount, 3, RoundingMode.HALF_EVEN).multiply(coupon.getAmount());
+        BigDecimal couponAmountTotal = coupon.getAmount();
+        BigDecimal remainingAmount = couponAmountTotal;
+        int size = orderItemList.size();
+        for (int i = 0; i < size; i++) {
+            OmsOrderItem orderItem = orderItemList.get(i);
+            BigDecimal couponAmount;
+            if (i < size - 1) {
+                //(商品价格/可用商品总价)*优惠券面额
+                couponAmount = orderItem.getProductPrice().divide(totalAmount, 3, RoundingMode.HALF_EVEN).multiply(couponAmountTotal);
+                remainingAmount = remainingAmount.subtract(couponAmount);
+            } else {
+                // last item gets the remainder to ensure total equals coupon amount
+                couponAmount = remainingAmount;
+            }
+            couponAmount = couponAmount.setScale(2, RoundingMode.HALF_UP);
             orderItem.setCouponAmount(couponAmount);
         }
     }

--- a/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPromotionServiceImpl.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPromotionServiceImpl.java
@@ -88,10 +88,10 @@ public class OmsPromotionServiceImpl implements OmsPromotionService {
                         BeanUtils.copyProperties(item,cartPromotionItem);
                         String message = getFullReductionPromotionMessage(fullReduction);
                         cartPromotionItem.setPromotionMessage(message);
-                        //(商品原价/总价)*满减金额
+                        //(商品原价/总价)*满减金额，使用 multiply-divide 顺序避免 divide 精度损失
                         PmsSkuStock skuStock= getOriginalPrice(promotionProduct, item.getProductSkuId());
                         BigDecimal originalPrice = skuStock.getPrice();
-                        BigDecimal reduceAmount = originalPrice.divide(totalAmount,RoundingMode.HALF_EVEN).multiply(fullReduction.getReducePrice());
+                        BigDecimal reduceAmount = originalPrice.multiply(fullReduction.getReducePrice()).divide(totalAmount, 2, RoundingMode.HALF_EVEN);
                         cartPromotionItem.setReduceAmount(reduceAmount);
                         cartPromotionItem.setRealStock(skuStock.getStock()-skuStock.getLockStock());
                         cartPromotionItem.setIntegration(promotionProduct.getGiftPoint());


### PR DESCRIPTION
## Bug 描述

**Issue:** [#356](https://github.com/macrozheng/mall/issues/356)

`OmsPortalOrderServiceImpl.calcPerCouponAmount()` 方法在计算优惠券分摊时，对每个商品独立计算并四舍五入到3位小数（`HALF_EVEN`），导致各商品分摊金额之和可能小于优惠券面额。

**复现案例：**
- 商品价格：10元、10元、10元
- 总价：30元
- 优惠券面额：10元
- 原算法：(10/30)*10 = 3.333... → 四舍五入为 3.330
- 三个商品分摊金额合计：9.990元，少了0.01元

## 修复方案

对前 `n-1` 个商品按比例计算分摊金额，最后一个商品获取剩余金额，确保分摊总额**精确等于**优惠券面额。最终金额四舍五入到2位小数。

```java
// 修复后的逻辑
for (int i = 0; i < size; i++) {
    if (i < size - 1) {
        // 前 n-1 个商品：按比例计算
        couponAmount = orderItem.getProductPrice().divide(totalAmount, 3, RoundingMode.HALF_EVEN).multiply(couponAmountTotal);
        remainingAmount = remainingAmount.subtract(couponAmount);
    } else {
        // 最后一个商品：获取剩余金额，确保总和精确等于优惠券面额
        couponAmount = remainingAmount;
    }
    couponAmount = couponAmount.setScale(2, RoundingMode.HALF_UP);
    orderItem.setCouponAmount(couponAmount);
}
```

## 修改文件

- `mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java`

Fixes #356