### PR TITLE
fix(RequestUtil): 修复 getLocalHost 失败时的 NPE 及 IP 解析逻辑错误

### DIFF
--- a/mall-common/src/main/java/com/macro/mall/common/util/RequestUtil.java
+++ b/mall-common/src/main/java/com/macro/mall/common/util/RequestUtil.java
@@ -26,20 +26,16 @@ public class RequestUtil {
             ipAddress = request.getRemoteAddr();
             // 从本地访问时根据网卡取本机配置的IP
             if (ipAddress.equals("127.0.0.1") || ipAddress.equals("0:0:0:0:0:0:0:1")) {
-                InetAddress inetAddress = null;
                 try {
-                    inetAddress = InetAddress.getLocalHost();
+                    ipAddress = InetAddress.getLocalHost().getHostAddress();
                 } catch (UnknownHostException e) {
-                    e.printStackTrace();
+                    ipAddress = "127.0.0.1";
                 }
-                ipAddress = inetAddress.getHostAddress();
             }
         }
         // 通过多个代理转发的情况，第一个IP为客户端真实IP，多个IP会按照','分割
-        if (ipAddress != null && ipAddress.length() > 15) {
-            if (ipAddress.indexOf(",") > 0) {
-                ipAddress = ipAddress.substring(0, ipAddress.indexOf(","));
-            }
+        if (ipAddress != null && ipAddress.contains(",")) {
+            ipAddress = ipAddress.substring(0, ipAddress.indexOf(","));
         }
         return ipAddress;
     }


### PR DESCRIPTION
## 问题

`RequestUtil.getRequestIp()` 方法存在两个 Bug：

### Bug 1：`InetAddress.getLocalHost()` 失败时抛出 NullPointerException

当 `InetAddress.getLocalHost()` 抛出 `UnknownHostException` 时，变量 `inetAddress` 保持为 `null`。随后代码在 try-catch 块**外部**调用 `inetAddress.getHostAddress()`，导致 `NullPointerException`。

### Bug 2：多代理场景下 IP 解析逻辑错误

原代码使用 `ipAddress.length() > 15` 来判断是否存在多个代理转发的 IP，该方式不可靠，原因如下：
- IPv6 地址（如 `0:0:0:0:0:0:0:1`）可能超过 15 个字符但不包含逗号
- 较短但含逗号的 IP 字符串（如 `1.1.1.1,2.2.2.2`）会被漏判

## 解决方案

**Bug 1：** 将 `getHostAddress()` 调用移入 try 块内，并在 catch 块中将 `ipAddress` 回退为 `"127.0.0.1"`。

**Bug 2：** 将 `ipAddress.length() > 15` 替换为 `ipAddress.contains(",")`，准确检测以逗号分隔的 IP 链。

## 改动文件

- `mall-common/src/main/java/com/macro/mall/common/util/RequestUtil.java`